### PR TITLE
Fix throwing on object without `constructor` or `toString` (fix #11)

### DIFF
--- a/objectSorter.js
+++ b/objectSorter.js
@@ -17,7 +17,7 @@ function _guessObjectType(obj) {
     return 'null';
   }
 
-  switch (obj.constructor.name) {
+  switch (obj.constructor && obj.constructor.name) {
     case 'Array':
     case 'Int8Array':
     case 'Uint8Array':
@@ -200,7 +200,10 @@ function makeObjectSorter(options) {
   };
 
   stringifier.unknown = function unknownToString(obj) {
-    return '<:' + obj.constructor.name + '>:' + obj.toString();
+    const constructorName = obj.constructor ? obj.constructor.name : 'no `constructor`';
+    const objectName = typeof obj.toString === 'function' ? obj.toString() : 'no `toString`';
+
+    return '<:' + constructorName + '>:' + objectName;
   };
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -44,6 +44,8 @@ var testData = {
       o: [5, 4, 3, 2, 1, 0],
       x: new UnknownClass(),
       y: true,
+      z: Object.create(null),
+      aa: Object.assign({}, {constructor: undefined})
     },
     noCoerce: {
       a: 1,
@@ -65,7 +67,9 @@ var testData = {
       },
       o: [5, 4, 3, 2, 1, 0],
       x: new UnknownClass(),
-      y: true
+      y: true,
+      z: Object.create(null),
+      aa: Object.assign({}, {constructor: undefined})
     },
     sort: {
       d: {
@@ -87,7 +91,9 @@ var testData = {
       i: null,
       m: Symbol(),
       x: new UnknownClass(),
-      y: new Boolean(true)
+      y: new Boolean(true),
+      z: Object.create(null),
+      aa: Object.assign({}, {constructor: undefined})
     },
     coerce: {
       a: true,
@@ -109,7 +115,9 @@ var testData = {
       },
       o: ['5', 4, '3', 2, true, false],
       x: new UnknownClass(),
-      y: true
+      y: true,
+      z: Object.create(null),
+      aa: Object.assign({}, {constructor: undefined})
     },
     sortCoerce: {
       b: 2,
@@ -131,7 +139,9 @@ var testData = {
       k: new Map([[2, 2], [3, 3], [1, 1]]),
       h: null,
       m: Symbol(),
-      y: new Number(1)
+      y: new Number(1),
+      z: Object.create(null),
+      aa: Object.assign({}, {constructor: undefined})
     }
   }
 };


### PR DESCRIPTION
#11