### PR TITLE
docs: Fix hasher default encoding documentation

### DIFF
--- a/src/hasher.ts
+++ b/src/hasher.ts
@@ -23,7 +23,7 @@ namespace hasher {
     alg?: string;
     /**
      * String encoding for hash
-     * @default 'base64'
+     * @default 'hex'
      */
     enc?: BinaryToTextEncoding;
   }


### PR DESCRIPTION
Update docs to match default value: https://github.com/SkeLLLa/node-object-hash/blob/bdd74211a509462d8faa408394485dbc67721dad/src/hasher.ts#L12