### PR TITLE
fix: Ensure hasher.ts can be polyfilled

### DIFF
--- a/src/hasher.ts
+++ b/src/hasher.ts
@@ -1,5 +1,5 @@
 import type { BinaryToTextEncoding } from 'crypto';
-import { createHash } from 'node:crypto';
+import { createHash } from 'crypto';
 
 import type { SorterOptions } from './objectSorter';
 import { objectSorter } from './objectSorter';


### PR DESCRIPTION
I think either update this import or update the readme about polyfill. Most browser polyfill at the moment only polyfill "crypto" and not "node:crypto"