### PR TITLE
fix: Objects without prototype are now properly stringified

### DIFF
--- a/__tests__/objectSorter.spec.ts
+++ b/__tests__/objectSorter.spec.ts
@@ -93,5 +93,13 @@ describe('Sorter', () => {
       const hash = hasher();
       expect(hash.sort(Object.create(null))).toBe('<:unknonw>:unknown');
     });
+    test('unknown with data', () => {
+      const hash = hasher();
+
+      const obj = Object.create(null) as Record<string, number>;
+      obj['a'] = 1;
+
+      expect(hash.sort(obj)).toBe('<:unknonw>:{"a":1}');
+    });
   });
 });

--- a/src/objectSorter.ts
+++ b/src/objectSorter.ts
@@ -226,7 +226,14 @@ export const objectSorter = (options?: SorterOptions): StringifyFn => {
     unknown: function _unknown(obj: Object) {
       // `unknonw` - is a typo, saved for backward compatibility
       const constructorName: string = obj.constructor?.name ?? 'unknonw';
-      const objectName = typeof obj.toString === 'function' ? obj.toString() : 'unknown';
+
+      let objectName = 'unknown';
+
+      if (typeof obj.toString === 'function') {
+        objectName = obj.toString();
+      } else if (Object.keys(obj).length > 0) {
+        objectName = JSON.stringify(obj);
+      }
 
       return `<:${constructorName}>:${objectName}`;
     },


### PR DESCRIPTION
Hey,

I recently discovered that I was using the same key for different object shapes. Upon further investigation, I realized that the object I was attempting to hash did not have prototypes. Following the package workflow, I found that all these objects are hashed using a fallback value `<:unknonw>:unknown`. These objects may still contain data despite not having prototypes.


Example : 
```javascript
import { hasher } from "node-object-hash";

const hashSortCoerce = hasher({
  sort: true,
  coerce: false,
  alg: "md5",
});

const obj0 = Object.create(null);
console.log(hashSortCoerce.hash(obj0)); // 9e6a14d0fc429751a97d11e74803128e

const obj1 = Object.create(null);
obj1.name = "something";
console.log(obj1); // { name: "something" }
console.log(hashSortCoerce.hash(obj1)); // 9e6a14d0fc429751a97d11e74803128e

const obj2 = Object.create(null);
obj2.name = "else";
console.log(obj2); // { name: "else" }
console.log(hashSortCoerce.hash(obj2)); // 9e6a14d0fc429751a97d11e74803128e
```

I resolved the issue on my end by wrapping the objects with prototypes, but I believe others might encounter the same problem, which is why I submitted this PR.

Thanks 😃 